### PR TITLE
referencing 0.37.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,17 @@
-{% set version = "0.30.2" %}
+{% set name = "referencing" %}
+{% set version = "0.37.0" %}
 
 package:
-  name: referencing
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/r/referencing/referencing-{{ version }}.tar.gz
-  sha256: 794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8
 
 build:
-  number: 1
+  number: 0
+  skip: true  # [py<310]
   script_env:
     - REFERENCING_SUITE=./suite
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -24,12 +26,17 @@ requirements:
     - attrs >=22.2.0
     - python
     - rpds-py >=0.7.0
+    - typing_extensions >=4.4.0  # [py<313]
 
 test:
   source_files:
     - suite
   imports:
     - referencing
+    - referencing.exceptions
+    - referencing.jsonschema
+    - referencing.retrieval
+    - referencing.typing
   commands:
     - pip check
     - pytest -vv --pyargs referencing --cov=referencing --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=99


### PR DESCRIPTION
referencing 0.37.0 

**Destination channel:** Defaults

### Links

- [PKG-10572]
- dev_url:        https://github.com/python-jsonschema/referencing/tree/v0.37.0
- conda_forge:    https://github.com/conda-forge/referencing-feedstock
- pypi:           https://pypi.org/project/referencing/0.37.0
- pypi inspector: https://inspector.pypi.io/project/referencing/0.37.0

### Explanation of changes:

- version updated from 0.30.2 to 0.37.0
- package name templated as {{ name|lower }}
- reset build number to 0
- added skip for py<310
- added typing_extensions >=4.4.0 for py<313
- added new test imports


[PKG-10572]: https://anaconda.atlassian.net/browse/PKG-10572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ